### PR TITLE
fix: Google vertex ai fixes in docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,16 @@ This project creates a Docker Compose setup with two main services:
 
 ### Before starting env variables:
 
+
 ```
 export VLLM_URL="http://SERVER_IP:11434/v1"
 export VERTEXAI_PROJECT="myproject"
-export VERTEXAI_ACCESS_TOKEN=$(gcloud auth print-access-token)
+```
+
+If using google, check that your google cloud account is running correctly:
+
+```
+gcloud auth list
 ```
 
 ### Using podman-compose

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,3 +1,7 @@
+secrets:
+  gcp-credentials:
+    file: ~/.config/gcloud/application_default_credentials.json
+
 services:
   llama-stack:
     image: docker.io/llamastack/distribution-starter:0.2.18
@@ -10,14 +14,16 @@ services:
     entrypoint: ["python", "-m", "llama_stack.core.server.server"]
     command: ["/app-root/run.yaml", "--port", "8321"]
     environment:
-      - VERTEXAI_ACCESS_TOKEN=${VERTEXAI_ACCESS_TOKEN}
       - VERTEXAI_PROJECT=${VERTEXAI_PROJECT}
+      - GOOGLE_APPLICATION_CREDENTIALS=/run/secrets/gcp-credentials
       - LLAMA_STACK_LOG=DEBUG
       - VLLM_URL=${VLLM_URL}
       - VLLM_API_TOKEN=test
       - VLLM_MAX_TOKENS=4096
       - VLLM_TLS_VERIFY=false
       - INFERENCE_MODEL=gemma3:27b-it-qat
+    secrets:
+      - gcp-credentials
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8321/v1/health"]
       interval: 5s

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,7 @@
 secrets:
   gcp-credentials:
     file: ~/.config/gcloud/application_default_credentials.json
+    x-podman.relabel: Z
 
 services:
   llama-stack:


### PR DESCRIPTION
The access-token is not valid with litellm, moving to credentials using docker-compose secrets, so it's easy that have an specific SA.